### PR TITLE
Replaces authenticate-pam

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   ],
   "dependencies": {
     "@osjs/event-emitter": "^1.0.6",
-    "authenticate-pam": "^1.0.2",
     "fs-extra": "^7.0.1",
     "node-ipc": "^9.1.1",
-    "userid": "^0.3.1",
+    "node-linux-pam": "0.0.1",
+    "userid": "^1.0.0-beta.6",
     "uuid": "^3.4.0"
   },
   "author": "Anders Evenrud <andersevenrud@gmail.com>",

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -77,7 +77,7 @@ const readCustomFile = options => username =>
 
 const authenticate = (username, password) =>
   new Promise((resolve, reject) =>
-    pamAuthenticate(username, password, err =>
+    pamAuthenticate({username, password}, err =>
       err ? reject(err) : resolve(true)));
 
 const readGroups = options => options.native

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -29,7 +29,7 @@
  */
 const userid = require('userid'); // TODO FIXME We don't need this anymore ?!
 const fs = require('fs-extra');
-const pam = require('authenticate-pam');
+const {pamAuthenticate} = require('node-linux-pam');
 
 const readNixGroups = () =>
   fs.readFile('/etc/group', 'utf8')
@@ -77,7 +77,7 @@ const readCustomFile = options => username =>
 
 const authenticate = (username, password) =>
   new Promise((resolve, reject) =>
-    pam.authenticate(username, password, err =>
+    pamAuthenticate(username, password, err =>
       err ? reject(err) : resolve(true)));
 
 const readGroups = options => options.native


### PR DESCRIPTION
Since authenticate-pam won't build, I've replaced it with another pam library that actually works. I also got errors with userid not being able to install so I bumped the version on that.